### PR TITLE
updating config.xml with revised code

### DIFF
--- a/app/code/local/PWS/Special/etc/config.xml
+++ b/app/code/local/PWS/Special/etc/config.xml
@@ -6,17 +6,20 @@
         </PWS_Special>
         <global>
             <blocks>
-                <special>
+                <pws_special>
                     <class>PWS_Special_Block</class>
-                </special>
+                </pws_special>
                 <catalog>
                     <rewrite>
-                        <Catalog_Product_Sales>
-                            PWS_Special_Block_Catalog_Product_Sales
-                        </Catalog_Product_Sales>
+                        <catalog_product_sales>PWS_Special_Block_Catalog_Product_Sales</catalog_product_sales>
                     </rewrite>
                 </catalog>
             </blocks>
+            <helpers>
+                <pws_special>
+                    <class>PWS_Special_Block</class>
+                </pws_special>
+            </helpers>
         </global>
     </modules>
 </config>


### PR DESCRIPTION
Updating config.xml file with helper definition and proper rewirte of the class `Mage_Catalog_Block_Product_Sales`. Please note `Mage_Catalog_Block_Product_Sales` is not present in default Magento. So it will work only if you have `Mage_Catalog_Block_Product_Sales` present in your Magento installation.
